### PR TITLE
Document the usage of a docker socket proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ curl -sSL https://raw.githubusercontent.com/Lifailon/logporter/refs/heads/main/d
 docker-compose up -d
 ```
 
-Use environment variables to apply custom metrics:
+Use environment variables to configure the exporter:
 
-| Lable                       | Type      | Default                        | Description                                                                                           |
-| -                           | -         | -                              | -                                                                                                     |
+| Label                       | Type      | Default                        | Description                                                                                           |
+| --------------------------- | --------- | ------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | `DOCKER_LOG_METRICS`        | `boolean` | `false`                        | Getting the number of messages in logs from all streams                                               |
 | `DOCKER_LOG_CUSTOM_METRICS` | `boolean` | `false`                        | Enable getting custom metrics                                                                         |
 | `DOCKER_LOG_CUSTOM_QUERY`   | `string`  | `\"(err\|error\|ERR\|ERROR)\"` | Custom filter query in regex format (default example is equivalent to `error` level in `json` format) |
+| `DOCKER_HOST`               | `string`  | `""`                           | Optional: Use a docker proxy instead of the docker socket mount for additional security.              |
 
 - Connect the new target in the `prometheus.yml` configuration:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,20 @@ services:
       - DOCKER_LOG_METRICS=false
       - DOCKER_LOG_CUSTOM_METRICS=false
       - DOCKER_LOG_CUSTOM_QUERY=\"(err|error|ERR|ERROR)\"
+      # Optional: Use a docker proxy instead of the docker socket mount for improved security.
+      # - DOCKER_HOST=tcp://proxy:2375
     ports:
       - 9333:9333
+
+  # Optional: A docker proxy service is only needed if DOCKER_PROXY is set.
+  # It improves security by filtering api calls and disallowing write operations.
+  proxy:
+    image: lscr.io/linuxserver/socket-proxy:latest
+    container_name: docker-proxy
+    restart: unless-stopped
+    expose:
+      - 2375
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - CONTAINERS=1


### PR DESCRIPTION
Thank you for this nice lightweight alternative to cadvisor!

I missed some documentation for the usage of a docker socket proxy in combination with this metrics collector and was surprised, that it is already implemented via the environment variable `DOCKER_HOST`. Maybe we should add the environment variable `DOCKER_HOST` for this to the README?

I also added a small example proxy to the Compose file as an simple PoC.